### PR TITLE
Clarification in sample code to indicate lower case

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ radbeacons = scanner.scan
 There is also a `fetch` method that returns a `Radbeacon::Usb` object for a given MAC address.
 
 ```
-radbeacon = scanner.fetch("11:22:33:44:55:66")
+radbeacon = scanner.fetch("11:22:33:44:55:aa")
 ```
 
 #### Scan Options


### PR DESCRIPTION
While working with this code, we experienced some issues related to fetch which ultimately were traced down to using upper case instead of lower case letters in the Mac address. The current Mac address sample only contains numbers. This commit proposes including a hint to use lower case letters.